### PR TITLE
Improve static build and have it as a feature

### DIFF
--- a/.appveyor/appveyor.bat
+++ b/.appveyor/appveyor.bat
@@ -115,3 +115,6 @@ if %ERRORLEVEL% NEQ 0 exit 1
 
 cargo test -vv %CARGO_MODE%
 if %ERRORLEVEL% NEQ 0 exit 1
+
+cargo test -vv --features static-libzmq %CARGO_MODE%
+if %ERRORLEVEL% NEQ 0 exit 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ unstable = []
 default = ["zmq_has"]
 zmq_has = [] # zmq_has was added in zeromq 4.1.
 unstable-testing = ["compiletest_rs", "unstable"]
+static-libzmq = ["zmq-sys/static-libzmq"]
 
 [[example]]
 name = "rtdealer"

--- a/zmq-sys/Cargo.toml
+++ b/zmq-sys/Cargo.toml
@@ -22,3 +22,6 @@ glob = "0.2.11"
 
 [package.metadata.pkg-config]
 libzmq = "4.1"
+
+[features]
+static-libzmq = []


### PR DESCRIPTION
Hi, I improved your build script and now it supports Linux too. A user can use `static-libzmq` in `Cargo.toml` to enable it.

I also changed the libzmq submodule commit to the latest official release.

Please merge it in your branch, so my changes will appear at your PR (erickt/rust-zmq#239).