### PR TITLE
Inform cargo about zmq-sys paths so other *-sys crates can use them

### DIFF
--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -32,6 +32,11 @@ fn build_static_libzmq() {
         // When compiled on 64bit system then default libdir is `lib64`, with
         // this we ensure that libdir will be `lib` on all systems.
         .define("CMAKE_INSTALL_LIBDIR", "lib")
+        // libzmq is using C99 standard but they do not specify it in their
+        // cmake. This is needed when user has an older C compiler which the
+        // default standard is lower than C99.
+        // One valid scenario is cross-compilation for Linux embedded systems.
+        .define("CMAKE_C_STANDARD", "99")
         .define("ENABLE_DRAFTS", "OFF")
         .define("BUILD_SHARED", "OFF")
         .define("BUILD_STATIC", "ON")

--- a/zmq-sys/build.rs
+++ b/zmq-sys/build.rs
@@ -37,6 +37,9 @@ fn build_static_libzmq() {
         .define("BUILD_STATIC", "ON")
         .build();
 
+    let lib_path = dst.join("lib");
+    let include_path = dst.join("include");
+
     if target.contains("msvc") {
         // Everything expects to link to zmq.lib, but the windows
         // build outputs a bunch of libs depending on runtime,
@@ -57,8 +60,7 @@ fn build_static_libzmq() {
             }
         };
 
-        let pattern = format!("{}", dst.join("lib").join(file_pattern).display());
-
+        let pattern = format!("{}", lib_path.join(file_pattern).display());
         let found_path = glob(&pattern)
             .expect("Failed to read file glob pattern.")
             .next()
@@ -67,7 +69,7 @@ fn build_static_libzmq() {
             )
             .unwrap();
 
-        let expected_path = dst.join("lib").join("zmq.lib");
+        let expected_path = lib_path.join("zmq.lib");
         std::fs::copy(&found_path, &expected_path).expect(&format!(
             "Unable to copy '{}' to '{}'",
             found_path.display(),
@@ -75,10 +77,9 @@ fn build_static_libzmq() {
         ));
     }
 
-    println!(
-        "cargo:rustc-link-search=native={}",
-        dst.join("lib").display()
-    );
+    println!("cargo:root={}", dst.display());
+    println!("cargo:include={}", include_path.display());
+    println!("cargo:rustc-link-search=native={}", lib_path.display());
     println!("cargo:rustc-link-lib=static=zmq");
 
     if target.contains("msvc") {


### PR DESCRIPTION
So after messing around with *-sys crates, I realize that is a good practice to expose paths with `cargo:root` and `cargo:include`.